### PR TITLE
refresh token

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -61,7 +61,15 @@
                   "maximumError": "10kb"
                 }
               ]
-            }
+            },
+            "dev": {
+              "fileReplacements": [
+                  {
+                      "replace": "src/environments/environment.ts",
+                      "with": "src/environments/environment.dev.ts"
+                  }
+              ]
+          }
           }
         },
         "serve": {
@@ -72,6 +80,9 @@
           "configurations": {
             "production": {
               "browserTarget": "preinscriptions-control:build:production"
+            },
+            "dev": {
+              "browserTarget": "preinscriptions-control:build:dev"
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "ng": "ng",
     "start": "node server.js",
     "build": "ng build",
-    "heroku-postbuild": "ng build --configuration=production",
+    "heroku-postbuild": "ng build --configuration=dev",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -62,7 +62,7 @@ export class AuthService {
       'refreshToken': this.getRefreshToken()
     }).pipe(
       tap((tokens: Tokens) => {
-        this.storeJwtToken(tokens.jwt);
+        this.storeTokens(tokens);
       })
     );
   }

--- a/src/app/auth/token-interceptor.service.ts
+++ b/src/app/auth/token-interceptor.service.ts
@@ -3,6 +3,7 @@ import { HttpRequest, HttpHandler, HttpEvent, HttpInterceptor, HttpErrorResponse
 import { AuthService } from '@auth/services/auth.service';
 import { Observable, throwError, BehaviorSubject } from 'rxjs';
 import { catchError, filter, take, switchMap } from 'rxjs/operators';
+import { Router } from '@angular/router';
 
 @Injectable()
 export class TokenInterceptorService implements HttpInterceptor {
@@ -10,7 +11,7 @@ export class TokenInterceptorService implements HttpInterceptor {
   private isRefreshing = false;
   private refreshTokenSubject: BehaviorSubject<any> = new BehaviorSubject<any>(null);
 
-  constructor(public authService: AuthService) { }
+  constructor(private authService: AuthService, private router: Router ) { }
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
 
@@ -19,8 +20,10 @@ export class TokenInterceptorService implements HttpInterceptor {
     }
 
     return next.handle(request).pipe(catchError(error => {
-      if (error instanceof HttpErrorResponse && error.status === 403) {
-        return this.handle403Error(request, next);
+      if (error instanceof HttpErrorResponse && error.status === 406) {
+        return this.handle406Error(request, next);
+      } else if (error instanceof HttpErrorResponse && error.status === 401){
+        this.handle401Error(request, next);
       }
       else {
         return this.errorHandler(error);
@@ -43,7 +46,8 @@ export class TokenInterceptorService implements HttpInterceptor {
     });
   }
 
-  private handle403Error(request: HttpRequest<any>, next: HttpHandler) {
+  // expired token handler
+  private handle406Error(request: HttpRequest<any>, next: HttpHandler) {
     if (!this.isRefreshing) {
       this.isRefreshing = true;
       this.refreshTokenSubject.next(null);
@@ -60,8 +64,16 @@ export class TokenInterceptorService implements HttpInterceptor {
         filter(token => token != null),
         take(1),
         switchMap(jwt => {
-          return next.handle(this.addToken(request, jwt));
-        }));
+        return next.handle(this.addToken(request, jwt));
+      }));
     }
   }
+
+  // user credentials handler
+  private handle401Error(request: HttpRequest<any>, next: HttpHandler) {
+    return this.authService.logout().subscribe(success => {
+      if(success) this.router.navigate(['/auth/login']);
+    });
+  }
+
 }

--- a/src/app/auth/token-interceptor.service.ts
+++ b/src/app/auth/token-interceptor.service.ts
@@ -22,8 +22,8 @@ export class TokenInterceptorService implements HttpInterceptor {
     return next.handle(request).pipe(catchError(error => {
       if (error instanceof HttpErrorResponse && error.status === 406) {
         return this.handle406Error(request, next);
-      } else if (error instanceof HttpErrorResponse && error.status === 401){
-        this.handle401Error(request, next);
+      } else if (error instanceof HttpErrorResponse && error.status === 417){
+        this.handle417Error(request, next);
       }
       else {
         return this.errorHandler(error);
@@ -70,7 +70,7 @@ export class TokenInterceptorService implements HttpInterceptor {
   }
 
   // user credentials handler
-  private handle401Error(request: HttpRequest<any>, next: HttpHandler) {
+  private handle417Error(request: HttpRequest<any>, next: HttpHandler) {
     return this.authService.logout().subscribe(success => {
       if(success) this.router.navigate(['/auth/login']);
     });

--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -1,0 +1,5 @@
+export const environment = {
+  production: true,
+  API_END_POINT: 'https://prescription-validator-api.herokuapp.com/api',
+  ANDES_API: 'https://app.andes.gob.ar/api'
+};


### PR DESCRIPTION
- Modificación en el código http de manejo de Refresh token 401 a 406, el cual contempla un token que ya expiró
- Se agrega el manejo al código http 417, en el cual se hace un trigger a la función logout, esto contempla un token invalido o una ausencia del mismo