### PR TITLE
Feat: authentication

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,5 @@
 import { BrowserModule } from '@angular/platform-browser';
-import { NgModule } from '@angular/core';
+import { NgModule, APP_INITIALIZER } from '@angular/core';
 
 import { AppRoutingModule, routingComponents } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -8,6 +8,10 @@ import { HttpClientModule } from '@angular/common/http';
 import { PatientsService } from './services/patients.service';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ReactiveFormsModule } from '@angular/forms';
+
+// app_initializer auth
+import { AuthService } from '@auth/services/auth.service';
+import { servicesOnRun } from '@auth/token-initializer';
 // moduules
 import { AuthModule } from '@auth/auth.module';
 import { PharmacistsModule } from '@pharmacists/pharmacists.module';
@@ -44,6 +48,12 @@ import { DatePipe } from '@angular/common';
     MatMenuModule
   ],
   providers: [
+    {
+      provide: APP_INITIALIZER,
+      useFactory: servicesOnRun,
+      multi: true,
+      deps: [AuthService]
+    },
     PatientsService,
     DatePipe,
     {provide: MAT_DATE_LOCALE, useValue: 'es-AR'}

--- a/src/app/auth/services/auth.service.ts
+++ b/src/app/auth/services/auth.service.ts
@@ -61,20 +61,6 @@ export class AuthService {
     );
   }
 
-  async logoutAsPromise(): Promise<boolean> {
-    const logoutResult: boolean = await this.http.post<any>(`${this.apiEndPoint}/auth/logout`, {
-      'refreshToken': this.getRefreshToken()
-    }).pipe(
-      tap(() => this.doLogoutUser()),
-      mapTo(true),
-      catchError(error => {
-        console.log(error.error);
-        return of(false);
-      })
-    ).toPromise();
-    return logoutResult;
-  }
-
   resetPassword(passwords: {oldPassword: string, newPassword: string}){
     return this.http.post<any>(`${this.apiEndPoint}/auth/reset-password`, passwords);
   }

--- a/src/app/auth/token-initializer.ts
+++ b/src/app/auth/token-initializer.ts
@@ -1,0 +1,5 @@
+import { AuthService } from '@auth/services/auth.service';
+
+export function servicesOnRun(authService: AuthService) {
+  return () => authService.load();
+}

--- a/src/app/auth/token-interceptor.service.ts
+++ b/src/app/auth/token-interceptor.service.ts
@@ -24,6 +24,7 @@ export class TokenInterceptorService implements HttpInterceptor {
         return this.handle406Error(request, next);
       } else if (error instanceof HttpErrorResponse && error.status === 417){
         this.handle417Error(request, next);
+        return throwError(error.error.message);
       }
       else {
         return this.errorHandler(error);


### PR DESCRIPTION
- Se agrega un control del token JWT, al iniciar la app. 
  - Si el token JWT o refresh_token no se encuentran en el navegador, redirecciona al login, automáticamente.
  - Si ambos tokens se encuentran en el navegador, se hace una llamada a la api para verificar el JWT:
    - Si el token es incorrecto: devuelve código 417, realizando el proceso de logout (remueve los tokens y redirecciona al login) 
    - Si el token es válido pero ya esta expirado, entonces devuelve código 406, el cual llama a la función refresh_token:
      - Si este no coincide con el token guardado en el usuario, entonces devuelve 417, realizando el proceso de logout (remueve los tokens y redirecciona al login).
      - Si el token coincide, entonces se genera un nuevo JWT Y refresh_token. Los cuales se guardan en el navegador. Por último termina la carga a la pantalla que se esta accediendo sin tener que volver a iniciar sesión.