### PR TITLE
fix(REC): repara filtro de paciente en busqueda de farmacias

### DIFF
--- a/src/app/pharmacists/components/prescription-list/prescription-list.component.ts
+++ b/src/app/pharmacists/components/prescription-list/prescription-list.component.ts
@@ -137,27 +137,15 @@ export class PrescriptionListComponent implements OnInit, AfterContentInit, OnDe
             dateTo: this.dateToFilter ? moment(this.dateToFilter).format('DD-MM-YYYY') : undefined
         };
 
-        // Obtener el DNI y sexo del paciente de los datos existentes o usar los últimos conocidos
-        let patientDni = '';
-        let patientSex = '';
-        if (this.dataSource.data.length > 0) {
-            // Intentar obtener el DNI y sexo del primer elemento
+        // Usar el DNI y sexo del paciente establecido por el padre (setPatientContext) prioritariamente
+        let patientDni = this.lastPatientDni;
+        let patientSex = this.lastPatientSex;
+
+        // Si no hay DNI conocido del contexto, intentar obtenerlo de los datos existentes
+        if (!patientDni && this.dataSource.data.length > 0) {
             const firstElement = this.dataSource.data[0];
             patientDni = firstElement.patient?.dni || firstElement.paciente?.documento || '';
             patientSex = firstElement.patient?.sex || firstElement.paciente?.sexo || '';
-            // Actualizar el último DNI y sexo conocidos si se encuentran
-            if (patientDni) {
-                this.lastPatientDni = patientDni;
-            }
-            if (patientSex) {
-                this.lastPatientSex = patientSex;
-            }
-        }
-
-        // Si no hay DNI en los datos actuales, usar el último DNI y sexo conocidos
-        if (!patientDni && this.lastPatientDni) {
-            patientDni = this.lastPatientDni;
-            patientSex = this.lastPatientSex;
         }
 
         // Si no hay DNI disponible, no hacer ninguna búsqueda


### PR DESCRIPTION
<!--
PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) NO olvidar correr los tests localmente antes de crear el PR.
5) Completar las siguientes secciones:

-->
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) o breve descripción del requerimiento -->

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Problema inicial:
En el formulario de farmacia (pharmacists-form), al buscar un paciente por DNI la primera vez funcionaba correctamente. Pero al cambiar el DNI y buscar un segundo paciente, la petición a la API seguía enviando el primer DNI en lugar del nuevo.

2. Solución aplicada:
Se modificó loadPrescriptions() para usar this.lastPatientDni / this.lastPatientSex como fuente primaria (valores recién establecidos por el padre vía setPatientContext), y solo recurrir a dataSource.data[0] como fallback si no hay un DNI conocido. De esta forma, al buscar un nuevo paciente, el DNI correcto se envía a la API sin ser pisado por datos obsoletos.


### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [ ] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->






